### PR TITLE
change the restart, it was not effective before

### DIFF
--- a/firewalld/config.sls
+++ b/firewalld/config.sls
@@ -13,7 +13,7 @@ directory_firewalld:
     - require:
       - pkg: package_firewalld # make sure package is installed
     - listen_in:
-      - service: service_firewalld # restart service
+      - module: service_firewalld # restart service
 
 config_firewalld:
   file.managed:
@@ -27,5 +27,5 @@ config_firewalld:
       - pkg: package_firewalld # make sure package is installed
       - file: directory_firewalld
     - listen_in: 
-      - service: service_firewalld # restart service
+      - module: service_firewalld # restart service
 

--- a/firewalld/init.sls
+++ b/firewalld/init.sls
@@ -24,7 +24,7 @@ package_firewalld:
   pkg.installed:
     - name: {{ firewalld.package }}
 
-service_firewalld:
+service_firewalld_running:
   service.running:
     - name: {{ firewalld.service }}
     - enable: True         # start on boot
@@ -33,8 +33,19 @@ service_firewalld:
       - file: config_firewalld
       - service: iptables  # ensure it's stopped
       - service: ip6tables # ensure it's stopped
-{% else %}
+
 service_firewalld:
+  module.wait:
+    - name: service.restart
+    - m_name: {{ firewalld.service }}
+    - require:
+      - pkg: package_firewalld
+      - file: config_firewalld
+      - service: iptables  # ensure it's stopped
+      - service: ip6tables # ensure it's stopped
+
+{% else %}
+service_firewalld_dead:
   service.dead:
     - name: {{ firewalld.service }}
     - enable: False # don't start on boot

--- a/firewalld/services.sls
+++ b/firewalld/services.sls
@@ -13,7 +13,7 @@ directory_firewalld_services:
     - require:
       - pkg: package_firewalld # make sure package is installed
     - listen_in:
-      - service: service_firewalld # restart service
+      - module: service_firewalld # restart service
 
 
 # == Define: firewalld.services
@@ -37,7 +37,7 @@ directory_firewalld_services:
       - pkg: package_firewalld # make sure package is installed
       - file: directory_firewalld_services
     - listen_in: 
-      - service: service_firewalld # restart service
+      - module: service_firewalld # restart service
     - context:
         name: {{ s_name }}
         service: {{ v }}

--- a/firewalld/zones.sls
+++ b/firewalld/zones.sls
@@ -13,8 +13,7 @@ directory_firewalld_zones:
     - require:
       - pkg: package_firewalld # make sure package is installed
     - listen_in:
-      - service: service_firewalld # restart service
-      
+      - module: service_firewalld # restart service
 
 # == Define: firewalld.zones
 #
@@ -35,7 +34,7 @@ directory_firewalld_zones:
       - pkg: package_firewalld # make sure package is installed
       - file: directory_firewalld_zones
     - listen_in: 
-      - service: service_firewalld   # restart service
+      - module: service_firewalld   # restart service
     - context:
         name: {{ z_name }}
         zone: {{ v }}


### PR DESCRIPTION
I changed the service.running which was not restarting firewalld to a module.wait with listeners.
Indeed before the rules where just applied after a reboot, so it might be the origin of a breach.
Now it's corresponding to the expect behaviour as described in the formula.