### PR TITLE
Added comment option for zone sources.

### DIFF
--- a/firewalld/files/zone.xml
+++ b/firewalld/files/zone.xml
@@ -10,7 +10,12 @@
 {%- endif %}
 {%- if 'sources' in zone %}
   {%- for v in zone.sources %}
+    {%- if 'comment' in v %}
+  <!-- {{ v.comment }} -->
+  <source address="{{ v.source }}" />
+    {%- else %}
   <source address="{{ v }}" />
+    {%- endif %}
   {%- endfor %}
 {%- endif %}
 {%- if 'services' in zone %}


### PR DESCRIPTION
This is useful for those who want to be able to label sources for a particular zone with a comment.  This change is backwards compatible.  

Previous and still applicable:

>      sources:
        - "fd56:225:f59b::/48"
        - "10.0.0.0/8"

With a comment:

>      sources:
        - comment: "Local IPv6 subnet"
          source: "fd56:225:f59b::/48"
        - comment: "Local IPv4 subnet"
          source: "10.0.0.0/8"

Comments can be omitted and previous syntax used for backwards compatibility:

>      sources:
        - "fd56:225:f59b::/48"
        - "10.0.0.0/8"
        - comment: "VPN Users"
          source: "192.168.254.0/24"