### PR TITLE
Reload service rather than restart

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ metadata.json
 *.swp
 *.tmp
 /.project
+.kitchen/
+.kitchen.local.yml

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -19,8 +19,6 @@ provisioner:
     firewalld.sls:
       firewalld:
         enabled: True
-        IndividualCalls: 'no'
-        LogDenied: 'off'
         services:
           glusterfs:
             short: glusterfs

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -1,0 +1,40 @@
+---
+driver:
+  name: vagrant
+
+platforms:
+  - name: centos-7.2
+
+provisioner:
+  name: salt_solo
+  salt_install: bootstrap
+  salt_bootstrap_url: https://bootstrap.saltstack.com
+  salt_version: latest
+  formula: firewalld
+  pillars:
+    top.sls:
+      base:
+        '*':
+          - firewalld
+    firewalld.sls:
+      firewalld:
+        enabled: True
+        IndividualCalls: 'no'
+        LogDenied: 'off'
+        services:
+          glusterfs:
+            short: glusterfs
+            description: 'GlusterFS network filesystem'
+            ports:
+              tcp:
+                - 24007-24008
+                - 49152-49200
+
+suites:
+  - name: default
+    provisioner:
+      salt_bootstrap_options: -X -d
+      state_top:
+        base:
+          '*':
+            - firewalld

--- a/firewalld/config.sls
+++ b/firewalld/config.sls
@@ -12,8 +12,6 @@ directory_firewalld:
     - mode: 750
     - require:
       - pkg: package_firewalld # make sure package is installed
-    - listen_in:
-      - module: service_firewalld # restart service
 
 config_firewalld:
   file.managed:
@@ -26,6 +24,7 @@ config_firewalld:
     - require:
       - pkg: package_firewalld # make sure package is installed
       - file: directory_firewalld
-    - listen_in: 
-      - module: service_firewalld # restart service
-
+    - require_in:
+      - service: service_firewalld
+    - watch_in:
+      - cmd: reload_firewalld # reload firewalld config

--- a/firewalld/direct.sls
+++ b/firewalld/direct.sls
@@ -5,7 +5,7 @@
 
 # == Define: firewalld.direct
 #
-# This defines a configuration for permanent direct chains, 
+# This defines a configuration for permanent direct chains,
 # rules and passtthroughs, see firewalld.direct (5) man page.
 
 {%- if firewalld.get('direct', False) %}
@@ -21,8 +21,10 @@
     - require:
       - pkg: package_firewalld # make sure package is installed
       - file: directory_firewalld
-    - listen_in: 
-      - module: service_firewalld # restart service
+    - require_in:
+      - service: service_firewalld
+    - watch_in:
+      - cmd: reload_firewalld # reload firewalld config
     - context:
         direct: {{ firewalld.direct|json }}
 {%- endif %}

--- a/firewalld/init.sls
+++ b/firewalld/init.sls
@@ -17,7 +17,7 @@ include:
 iptables:
   service.disabled:
     - enable: False
-    
+
 ip6tables:
   service.disabled:
     - enable: False
@@ -26,7 +26,7 @@ package_firewalld:
   pkg.installed:
     - name: {{ firewalld.package }}
 
-service_firewalld_running:
+service_firewalld:
   service.running:
     - name: {{ firewalld.service }}
     - enable: True         # start on boot
@@ -36,18 +36,14 @@ service_firewalld_running:
       - service: iptables  # ensure it's stopped
       - service: ip6tables # ensure it's stopped
 
-service_firewalld:
-  module.wait:
-    - name: service.restart
-    - m_name: {{ firewalld.service }}
+reload_firewalld:
+  cmd.wait:
+    - name: 'firewall-cmd --reload'
     - require:
-      - pkg: package_firewalld
-      - file: config_firewalld
-      - service: iptables  # ensure it's stopped
-      - service: ip6tables # ensure it's stopped
+      - service: service_firewalld
 
 {% else %}
-service_firewalld_dead:
+service_firewalld:
   service.dead:
     - name: {{ firewalld.service }}
     - enable: False # don't start on boot

--- a/firewalld/ipsets.sls
+++ b/firewalld/ipsets.sls
@@ -17,8 +17,10 @@ directory_firewalld_ipsets:
     - mode: 750
     - require:
       - pkg: package_firewalld # make sure package is installed
-    - listen_in:
-      - module: service_firewalld # restart service
+    - require_in:
+      - service: service_firewalld
+    - watch_in:
+      - cmd: reload_firewalld # reload firewalld config
 
 # == Define: firewalld.ipsets
 #
@@ -38,8 +40,10 @@ directory_firewalld_ipsets:
     - require:
       - pkg: package_firewalld # make sure package is installed
       - file: directory_firewalld_ipsets
-    - listen_in: 
-      - module: service_firewalld   # restart service
+    - require_in:
+      - service: service_firewalld
+    - watch_in:
+      - cmd: reload_firewalld # reload firewalld config
     - context:
         name: {{ z_name }}
         ipset: {{ v }}

--- a/firewalld/services.sls
+++ b/firewalld/services.sls
@@ -12,8 +12,10 @@ directory_firewalld_services:
     - mode: 750
     - require:
       - pkg: package_firewalld # make sure package is installed
-    - listen_in:
-      - module: service_firewalld # restart service
+    - require_in:
+      - service: service_firewalld
+    - watch_in:
+      - cmd: reload_firewalld # reload firewalld config
 
 
 # == Define: firewalld.services
@@ -36,8 +38,10 @@ directory_firewalld_services:
     - require:
       - pkg: package_firewalld # make sure package is installed
       - file: directory_firewalld_services
-    - listen_in: 
-      - module: service_firewalld # restart service
+    - require_in:
+      - service: service_firewalld
+    - watch_in:
+      - cmd: reload_firewalld # reload firewalld config
     - context:
         name: {{ s_name }}
         service: {{ v|json }}

--- a/firewalld/zones.sls
+++ b/firewalld/zones.sls
@@ -12,8 +12,10 @@ directory_firewalld_zones:
     - mode: 750
     - require:
       - pkg: package_firewalld # make sure package is installed
-    - listen_in:
-      - module: service_firewalld # restart service
+    - require_in:
+      - service: service_firewalld
+    - watch_in:
+      - cmd: reload_firewalld # reload firewalld config
 
 # == Define: firewalld.zones
 #
@@ -33,8 +35,10 @@ directory_firewalld_zones:
     - require:
       - pkg: package_firewalld # make sure package is installed
       - file: directory_firewalld_zones
-    - listen_in: 
-      - module: service_firewalld   # restart service
+    - require_in:
+      - service: service_firewalld
+    - watch_in:
+      - cmd: reload_firewalld # reload firewalld config
     - context:
         name: {{ z_name }}
         zone: {{ v|json }}

--- a/test/integration/default/serverspec/firewalld_server_spec.rb
+++ b/test/integration/default/serverspec/firewalld_server_spec.rb
@@ -1,0 +1,6 @@
+require 'serverspec'
+set :backend, :exec
+
+describe service('firewalld') do
+  it { should be_running }
+end


### PR DESCRIPTION
The Salt Minion does not react well to FirewallD being restarted. It becomes unreachable indefinitely, until it is restarted. Further, I don't know of any reasons to restart the FirewallD service, since the service dynamically manages the kernel module.

This PR makes the service reload its conifg, rather than restarting.