### PR TITLE
Add support for using ipsets as sources in a zone

### DIFF
--- a/firewalld/files/zone.xml
+++ b/firewalld/files/zone.xml
@@ -23,6 +23,16 @@
     {%- endif %}
   {%- endfor %}
 {%- endif %}
+{%- if 'ipsets' in zone %}
+  {%- for v in zone.ipsets %}
+    {%- if 'comment' in v %}
+  <!-- {{ v.comment }} -->
+  <source ipset="{{ v.ipset }}" />
+    {%- else %}
+  <source ipset="{{ v }}" />
+    {%- endif %}
+  {%- endfor %}
+{%- endif %}
 {%- if 'services' in zone %}
   {%- for v in zone.services %}
   <service name="{{ v }}" />


### PR DESCRIPTION
I wanted to be able to add an ipset as a source in the zone without using a rich rule.  I believe this change accomplishes that.  I basically copied the section for sources within a zone.  Tested and working on CentOS 7 (salt master and minion).

Example usage:

  zones:
    public:
      short: Public
      description: "For use in public areas. You do not trust the other computers on networks to not harm your computer. Only selected incoming connections are accepted."
      services:
        - http
        - https
        - ssh
      ipsets:
        - sample-ip-set
        - comment: "ipset with a comment"
          ipset: sample-ip-set-with-comment