### PR TITLE
Default file permission for firewalld.conf

### DIFF
--- a/firewalld/config.sls
+++ b/firewalld/config.sls
@@ -18,7 +18,7 @@ config_firewalld:
     - name: /etc/firewalld/firewalld.conf
     - user: root
     - group: root
-    - mode: 640
+    - mode: 644
     - source: salt://firewalld/files/firewalld.conf
     - template: jinja
     - require:


### PR DESCRIPTION
Default file permission for firewalld.conf is 644 not 640 (CentOS). Even if I think that "others" don't need to read that, it always shows up as a file with non-default permissions from default rpm package in security scans. e.g. "rpm -Va |grep ^.M" or more salty way: "salt '*' pkg.verify" / salt '*' pkg.modified firewalld mode=True; manual fix e.g. rpm --setperms firewalld-*.el7.noarch