### PR TITLE
Fix ipset:type colon handling error

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -58,8 +58,8 @@ Salt Compatibility
 
 Tested with:
 
-* 2014.1.x
-* 2015.5.x
+* 2017.7.x
+* 2018.3.x
 
 OS Compatibility
 ================

--- a/firewalld/ipsets.sls
+++ b/firewalld/ipsets.sls
@@ -45,8 +45,7 @@ directory_firewalld_ipsets:
     - watch_in:
       - cmd: reload_firewalld # reload firewalld config
     - context:
-        name: {{ z_name }}
-        ipset: {{ v }}
+        ipset: {{ v|json_encode_dict }}
 
 {% endfor %}
 {%- endif %}


### PR DESCRIPTION
When using ipsets, `type` is a mandatory parameter, with values like `hash:ip`, `hash:ip,port,net` etc. (as returned by `firewall-cmd --get-ipset-types`).

However, using this pillar:

```yaml
firewalld:
  enabled: true
  ipset: true
  zones:
    mysql_clients:
      services:
        - mysql
      ipsets:
        - mysql
  ipsets:
    mysql:
      type: 'hash:ip'
      entries:
        - 192.168.0.1
        - 192.168.0.2
        - 192.168.1.0/24
```
Fails to render, wth the following error:

```
       [CRITICAL] Rendering SLS 'base:firewalld.ipsets' failed: found unexpected ':'; line 47
       
       ---
       [...]
             - service: service_firewalld
           - watch_in:
             - cmd: reload_firewalld # reload firewalld config
           - context:
        name: mysql
        ipset: {u'type': u'hash:ip', u'entries': [u'192.168.0.1', u'192.168.0.2', u'192.168.1.0/24']}    <======================
 ```

This PR fixes this error. Note that it uses a jinja filter available on Salt 2017.7.0 and newer, so it's not backward compatible.