### PR TITLE
Revert "Fix ipset:type colon handling error"

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -58,8 +58,8 @@ Salt Compatibility
 
 Tested with:
 
-* 2017.7.x
-* 2018.3.x
+* 2014.1.x
+* 2015.5.x
 
 OS Compatibility
 ================

--- a/firewalld/ipsets.sls
+++ b/firewalld/ipsets.sls
@@ -45,7 +45,8 @@ directory_firewalld_ipsets:
     - watch_in:
       - cmd: reload_firewalld # reload firewalld config
     - context:
-        ipset: {{ v|json_encode_dict }}
+        name: {{ z_name }}
+        ipset: {{ v }}
 
 {% endfor %}
 {%- endif %}


### PR DESCRIPTION
Reverts saltstack-formulas/firewalld-formula#16

breaks on 2018.3.0