### PR TITLE
notify nosupport if SLES version < 15

### DIFF
--- a/firewalld/init.sls
+++ b/firewalld/init.sls
@@ -5,7 +5,16 @@
 #
 {% from "firewalld/map.jinja" import firewalld with context %}
 
-{% if salt['pillar.get']('firewalld:enabled') %}
+{% if salt['grains.get']('osfullname') == "SLES" and salt['grains.get']('osmajorrelease')|int < 15 %}
+
+firewalld-unsupported:
+  test.show_notification:
+    - text: |
+        Firewalld is not supported on {{ grains['osfinger'] }}
+        See https://www.suse.com/releasenotes/x86_64/SUSE-SLES/15/#fate-323460
+
+{% elif salt['pillar.get']('firewalld:enabled') %}
+
 include:
   - firewalld.config
   - firewalld.ipsets
@@ -43,8 +52,10 @@ reload_firewalld:
       - service: service_firewalld
 
 {% else %}
+
 service_firewalld:
   service.dead:
     - name: {{ firewalld.service }}
     - enable: False # don't start on boot
+
 {% endif %}


### PR DESCRIPTION
If using SLES version < 15, then `firewalld` is unsupported.  Fix ugly failure (#18) for SLES 12.3
```
local:
----------
          ID: firewalld-unsupported
    Function: test.show_notification
      Result: True
     Comment: Firewalld is not supported on SLES-12
              See https://www.suse.com/releasenotes/x86_64/SUSE-SLES/15/#fate-323460
     Started: 14:33:56.930370
    Duration: 0.322 ms
     Changes:  
```

verified on SLES 12.3