### PR TITLE
Remove name attribute in icmp-block-inversion

### DIFF
--- a/firewalld/files/zone.xml
+++ b/firewalld/files/zone.xml
@@ -56,8 +56,8 @@
   <icmp-block name="{{ v }}" />
   {%- endfor %}
 {%- endif %}
-{%- if 'icmp_block_inversion' in zone %}
-  <icmp-block-inversion name="{{ zone.icmp_block_inversion }}" />
+{%- if 'icmp_block_inversion' in zone and zone.icmp_block_inversion %}
+  <icmp-block-inversion />
 {%- endif %}
 {%- if 'masquerade' in zone %}
   {%- if zone.masquerade %}


### PR DESCRIPTION
Attempt 2. =-)
First one fixed Salt. This one fixes firewalld.

\-

Firewalld does not parse the name attribute.

Log message:
firewalld[1999]: ERROR: Failed to load zone file 'public.xml':
PARSE_ERROR: icmp-block-inversion: Unexpected attribute name


### PR progress checklist (to be filled in by reviewers)

- [ ] Changes to documentation are appropriate (or tick if not required)
- [ ] Changes to tests are appropriate (or tick if not required)
- [ ] Reviews completed

---

### What type of PR is this?

#### Primary type

- [ ] `[build]`    Changes related to the build system
- [ ] `[chore]`    Changes to the build process or auxiliary tools and libraries such as documentation generation
- [ ] `[ci]`       Changes to the continuous integration configuration
- [ ] `[feat]`     A new feature
- [x] `[fix]`      A bug fix
- [ ] `[perf]`     A code change that improves performance
- [ ] `[refactor]` A code change that neither fixes a bug nor adds a feature
- [ ] `[revert]`   A change used to revert a previous commit
- [ ] `[style]`    Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc.)

### Does this PR introduce a `BREAKING CHANGE`?
<!-- If so, change the following to a `Yes` and explain what the breaking changes are. -->
<!-- If there are multiple breaking changes, list them all. -->

No.

### Related issues and/or pull requests
#31 

