### PR TITLE
fix: do not error on unknown os_family grain

### DIFF
--- a/firewalld/defaults.yaml
+++ b/firewalld/defaults.yaml
@@ -1,18 +1,19 @@
 # -*- coding: utf-8 -*-
 # vim: ft=yaml
 ---
-firewalld:
-  enabled: true
-  package: firewalld
-  service: firewalld
-  config: /etc/firewalld.conf
+default:
+  firewalld:
+    enabled: true
+    package: firewalld
+    service: firewalld
+    config: /etc/firewalld.conf
 
-  ipset:
-    manage: false
-    pkg: ipset
+    ipset:
+      manage: false
+      pkg: ipset
 
-  backend:
-    manage: false
-    pkg: nftables
+    backend:
+      manage: false
+      pkg: nftables
 
-  ipsets: {}
+    ipsets: {}

--- a/firewalld/defaults.yaml
+++ b/firewalld/defaults.yaml
@@ -1,19 +1,18 @@
 # -*- coding: utf-8 -*-
 # vim: ft=yaml
 ---
-default:
-  firewalld:
-    enabled: true
-    package: firewalld
-    service: firewalld
-    config: /etc/firewalld.conf
+firewalld:
+  enabled: true
+  package: firewalld
+  service: firewalld
+  config: /etc/firewalld.conf
 
-    ipset:
-      manage: false
-      pkg: ipset
+  ipset:
+    manage: false
+    pkg: ipset
 
-    backend:
-      manage: false
-      pkg: nftables
+  backend:
+    manage: false
+    pkg: nftables
 
-    ipsets: {}
+  ipsets: {}

--- a/firewalld/map.jinja
+++ b/firewalld/map.jinja
@@ -3,18 +3,28 @@
 
 {#- Start with  defaults from defaults.yaml #}
 {% import_yaml "firewalld/defaults.yaml" as default_settings %}
+{% import_yaml "firewalld/osarchmap.yaml" as osarchmap %}
 {% import_yaml "firewalld/osfamilymap.yaml" as osfamilymap %}
+{% import_yaml "firewalld/osmap.yaml" as osmap %}
+{% import_yaml "firewalld/osfingermap.yaml" as osfingermap %}
 
-{% set platform_defaults = salt['grains.filter_by'](default_settings,
-    default='default',
-    merge=salt['grains.filter_by'](osfamilymap, grain='os_family',
-      merge=salt['pillar.get']('firewalld:lookup')
+{% set _config = salt['config.get']('firewalld', default={}) %}
+
+{% set defaults = salt['grains.filter_by'](default_settings,
+    default='firewalld',
+    merge=salt['grains.filter_by'](osarchmap, grain='osarch',
+      merge=salt['grains.filter_by'](osfamilymap, grain='os_family',
+        merge=salt['grains.filter_by'](osmap, grain='os',
+          merge=salt['grains.filter_by'](osfingermap, grain='osfinger',
+            merge=salt['grains.filter_by'](_config, default='lookup')
+          )
+        )
+      )
     )
 ) %}
 
-{#- Merge in salt:lookup pillar #}
-{% set firewalld = salt['pillar.get'](
-    'firewalld',
-    default=platform_defaults.firewalld,
-    merge=True)
-%}
+{% set firewalld = salt['grains.filter_by'](
+    {'defaults': defaults},
+    default='defaults',
+    merge=_config
+) %}

--- a/firewalld/map.jinja
+++ b/firewalld/map.jinja
@@ -3,25 +3,18 @@
 
 {#- Start with  defaults from defaults.yaml #}
 {% import_yaml "firewalld/defaults.yaml" as default_settings %}
+{% import_yaml "firewalld/osfamilymap.yaml" as osfamilymap %}
 
-{#-
-Setup variable using grains['os_family'] based logic, only add key:values here
-that differ from whats in defaults.yaml
-#}
-{% set os_family_map = salt['grains.filter_by']({
-    'Debian': {},
-    'RedHat': {},
-    'Arch': {},
-    'Suse': {},
-  }, grain='os_family', merge=salt['pillar.get']('firewalld:lookup'))
-%}
-
-{#- Merge the flavor_map to the default settings #}
-{% do default_settings.firewalld.update(os_family_map) %}
+{% set platform_defaults = salt['grains.filter_by'](default_settings,
+    default='default',
+    merge=salt['grains.filter_by'](osfamilymap, grain='os_family',
+      merge=salt['pillar.get']('firewalld:lookup')
+    )
+) %}
 
 {#- Merge in salt:lookup pillar #}
 {% set firewalld = salt['pillar.get'](
     'firewalld',
-    default=default_settings.firewalld,
+    default=platform_defaults.firewalld,
     merge=True)
 %}

--- a/firewalld/osarchmap.yaml
+++ b/firewalld/osarchmap.yaml
@@ -1,0 +1,35 @@
+# -*- coding: utf-8 -*-
+# vim: ft=yaml
+#
+# Setup variables using grains['osarch'] based logic.
+# You just need to add the key:values for an `osarch` that differ
+# from `defaults.yaml`.
+# Only add an `osarch` which is/will be supported by the formula.
+#
+# If you do not need to provide defaults via the `osarch` grain,
+# you will need to provide at least an empty dict in this file, e.g.
+# osarch: {}
+---
+amd64:
+  arch: amd64
+
+x86_64:
+  arch: amd64
+
+386:
+  arch: 386
+
+arm64:
+  arch: arm64
+
+armv6l:
+  arch: armv6l
+
+armv7l:
+  arch: armv7l
+
+ppc64le:
+  arch: ppc64le
+
+s390x:
+  arch: s390x

--- a/firewalld/osfamilymap.yaml
+++ b/firewalld/osfamilymap.yaml
@@ -1,13 +1,33 @@
 # -*- coding: utf-8 -*-
-# # vim: ft=yaml
-# os_family defaults
-# only add key:values here that differ from whats in defaults.yaml
+# vim: ft=yaml
+#
+# Setup variables using grains['os_family'] based logic.
+# You just need to add the key:values for an `os_family` that differ
+# from `defaults.yaml` + `osarch.yaml`.
+# Only add an `os_family` which is/will be supported by the formula.
+#
+# If you do not need to provide defaults via the `os_family` grain,
+# you will need to provide at least an empty dict in this file, e.g.
+# osfamilymap: {}
 ---
-Debian:
-  firewalld: {}
-RedHat:
-  firewalld: {}
-Arch:
-  firewalld: {}
-Suse:
-  firewalld: {}
+Debian: {}
+
+RedHat: {}
+
+Suse: {}
+
+Gentoo: {}
+
+Arch: {}
+
+Alpine: {}
+
+FreeBSD: {}
+
+OpenBSD: {}
+
+Solaris: {}
+
+Windows: {}
+
+MacOS: {}

--- a/firewalld/osfamilymap.yaml
+++ b/firewalld/osfamilymap.yaml
@@ -1,0 +1,13 @@
+# -*- coding: utf-8 -*-
+# # vim: ft=yaml
+# os_family defaults
+# only add key:values here that differ from whats in defaults.yaml
+---
+Debian:
+  firewalld: {}
+RedHat:
+  firewalld: {}
+Arch:
+  firewalld: {}
+Suse:
+  firewalld: {}

--- a/firewalld/osfingermap.yaml
+++ b/firewalld/osfingermap.yaml
@@ -1,0 +1,45 @@
+# -*- coding: utf-8 -*-
+# vim: ft=yaml
+#
+# Setup variables using grains['osfinger'] based logic.
+# You just need to add the key:values for an `osfinger` that differ
+# from `defaults.yaml` + `osarch.yaml` + `os_family.yaml` + `osmap.yaml`.
+# Only add an `osfinger` which is/will be supported by the formula.
+#
+# If you do not need to provide defaults via the `os_finger` grain,
+# you will need to provide at least an empty dict in this file, e.g.
+# osfingermap: {}
+---
+# os: Debian
+Debian-10: {}
+Debian-9: {}
+Debian-8: {}
+
+# os: Ubuntu
+Ubuntu-18.04: {}
+Ubuntu-16.04: {}
+
+# os: Fedora
+Fedora-31: {}
+Fedora-30: {}
+
+# os: CentOS
+CentOS Linux-8: {}
+CentOS Linux-7: {}
+CentOS-6: {}
+
+# os: Amazon
+Amazon Linux-2: {}
+Amazon Linux AMI-2018: {}
+
+# os: SUSE
+Leap-15: {}
+
+# os: FreeBSD
+FreeBSD-12: {}
+
+# os: Windows
+Windows-8.1: {}
+
+# os: Gentoo
+Gentoo-2: {}

--- a/firewalld/osmap.yaml
+++ b/firewalld/osmap.yaml
@@ -1,0 +1,33 @@
+# -*- coding: utf-8 -*-
+# vim: ft=yaml
+#
+# Setup variables using grains['os'] based logic.
+# You just need to add the key:values for an `os` that differ
+# from `defaults.yaml` + `osarch.yaml` + `os_family.yaml`.
+# Only add an `os` which is/will be supported by the formula.
+#
+# If you do not need to provide defaults via the `os` grain,
+# you will need to provide at least an empty dict in this file, e.g.
+# osmap: {}
+---
+# os_family: Debian
+Ubuntu: {}
+Raspbian: {}
+
+# os_family: RedHat
+Fedora: {}
+CentOS: {}
+Amazon: {}
+
+# os_family: Suse
+SUSE: {}
+openSUSE: {}
+
+# os_family: Gentoo
+Funtoo: {}
+
+# os_family: Arch
+Manjaro: {}
+
+# os_family: Solaris
+SmartOS: {}

--- a/test/integration/default/controls/yaml_dump_spec.rb
+++ b/test/integration/default/controls/yaml_dump_spec.rb
@@ -11,6 +11,7 @@ control 'firewalld `map.jinja` YAML dump' do
     IndividualCalls: 'no'
     LogDenied: 'off'
     RFC3964_IPv4: 'yes'
+    arch: amd64
     backend:
       manage: true
       pkg: nftables


### PR DESCRIPTION
If the formula was ran on a system that reported an os_family that
wasn't one of "Debian", "RedHat", "Arch", "Suse" then the map.jinja
template would fail to render with "'NoneType' is not iterable.

This occurs because grains.filter_by will return None when it fails
match the grain to the input dictionary. The value is then blindly
passed into a dict.update() which causes the failure.

In this patch we ensure that the default values, as defined in
defaults.yaml, are always applied when grain matching fails.

<!--
Please fill in this PR template to make it easier to review and merge.

It has been designed so that a lot of it can be completed *after* submitting it,
e.g. filling in the checklists.

Notes:
1. Please keep the PR as small as is practicable; the larger a PR gets, the harder it becomes to review and the more time it requires to get it merged.
2. Similarly, please avoid PRs that cover more than one type; it should be a _bug fix_ *OR* a _new feature_ *OR* a _refactor_, etc.
3. Please direct questions to the [`#formulas` channel on Slack](https://saltstackcommunity.slack.com/messages/C7LG8SV54/), which is bridged to `#saltstack-formulas` on Freenode.
4. Feel free to suggest improvements to this template by reporting an issue or submitting a PR.  The source of this template is:
  - https://github.com/saltstack-formulas/.github/blob/master/.github/pull_request_template.md
-->

### PR progress checklist (to be filled in by reviewers)
<!-- Please leave this checklist for reviewers to tick as they work through the PR. -->

- [ ] Changes to documentation are appropriate (or tick if not required)
- [ ] Changes to tests are appropriate (or tick if not required)
- [ ] Reviews completed

---

### What type of PR is this?
<!-- Please tick each box that is relevant (after creating the PR). -->

#### Primary type
<!-- There really should be only *one* of these types ticked for each PR. -->

- [ ] `[build]`    Changes related to the build system
- [ ] `[chore]`    Changes to the build process or auxiliary tools and libraries such as documentation generation
- [ ] `[ci]`       Changes to the continuous integration configuration
- [ ] `[feat]`     A new feature
- [x] `[fix]`      A bug fix
- [ ] `[perf]`     A code change that improves performance
- [x] `[refactor]` A code change that neither fixes a bug nor adds a feature
- [ ] `[revert]`   A change used to revert a previous commit
- [ ] `[style]`    Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc.)

#### Secondary type
<!-- Most PRs should include all of the following types as well. -->

- [ ] `[docs]`     Documentation changes
- [ ] `[test]`     Adding missing or correcting existing tests

### Does this PR introduce a `BREAKING CHANGE`?
<!-- If so, change the following to a `Yes` and explain what the breaking changes are. -->
<!-- If there are multiple breaking changes, list them all. -->

No.

### Related issues and/or pull requests
<!-- Please link any related issues/PRs here, especially any issues that are closed by this PR. -->

None.

### Describe the changes you're proposing
<!-- A clear and concise description of what you have implemented. -->
<!-- Consider explaining each commit if they cover different aspects of the proposed changes. -->

Fix map.jinja template rendering. Do not fail when the system reports an unknown os_family grain.

### Pillar / config required to test the proposed changes
<!-- Provide links to the SLS files and/or relevant configs (be sure to remove sensitive info). -->

A system that reports a os_family value that is different from "Debian", "RedHat", "Arch", "Suse" . This error was brought to our attention when the formula was mistakenly ran on a MacOS machine. The formula isn't supposed to work on MacOS, but this error is platform agnostic. There may be some Distribution using firewalld that does not match the known os_family grains.


### Debug log showing how the proposed changes work
<!-- Include a debug log showing how these changes work, e.g. using `salt-minion -l debug`. -->
<!-- Alternatively, linking to Kitchen debug logs is useful, e.g. via. Travis CI. -->
<!-- Most useful is providing a passing InSpec test, which can be used to verify any proposed changes. -->

I have a traceback. The fix prevents the traceback. Should more debugging be required then I can get it.
```
local:
    Data failed to compile:
----------
    Rendering SLS 'cos-sdaniele3-dev:firewalld' failed: Jinja error: 'NoneType' object is not iterable
/var/cache/salt/minion/files/cos-sdaniele3-dev/firewalld/map.jinja(20):
---
[...]
    'Suse': {},
  }, grain='os_family', merge=salt['pillar.get']('firewalld:lookup'))
%}

{#- Merge the flavor_map to the default settings #}
{% do default_settings.firewalld.update(os_family_map) %}    <======================

{#- Merge in salt:lookup pillar #}
{% set firewalld = salt['pillar.get'](
    'firewalld',
    default=default_settings.firewalld,
[...]
---
Traceback (most recent call last):
  File "/opt/salt/lib/python2.7/site-packages/salt/utils/templates.py", line 393, in render_jinja_tmpl
    output = template.render(**decoded_context)
  File "/opt/salt/lib/python2.7/site-packages/jinja2/environment.py", line 1008, in render
    return self.environment.handle_exception(exc_info, True)
  File "/opt/salt/lib/python2.7/site-packages/jinja2/environment.py", line 780, in handle_exception
    reraise(exc_type, exc_value, tb)
  File "<template>", line 6, in top-level template code
  File "/opt/salt/lib/python2.7/site-packages/jinja2/environment.py", line 1073, in make_module
    return TemplateModule(self, self.new_context(vars, shared, locals))
  File "/opt/salt/lib/python2.7/site-packages/jinja2/environment.py", line 1152, in __init__
    body_stream = list(template.root_render_func(context))
  File "/var/cache/salt/minion/files/cos-sdaniele3-dev/firewalld/map.jinja", line 20, in top-level template code
    {% do default_settings.firewalld.update(os_family_map) %}
TypeError: 'NoneType' object is not iterable
```



### Documentation checklist
<!-- Please tick each box that is relevant (after creating the PR). -->

- [x] Updated the `README` (e.g. `Available states`).
- [x] Updated `pillar.example`.

### Testing checklist
<!-- Please tick each box that is relevant (after creating the PR). -->

- [ ] Included in Kitchen (i.e. under `state_top`).
- [ ] Covered by new/existing tests (e.g. InSpec, Serverspec, etc.).
- [ ] Updated the relevant test pillar.

### Additional context
<!-- Add any other context about the proposed changes here. -->


