### PR TITLE
feat(firewalld.conf): support configuration of `AllowZoneDrifting`

### DIFF
--- a/firewalld/files/firewalld.conf
+++ b/firewalld/files/firewalld.conf
@@ -95,3 +95,18 @@ FlushAllOnReload={{ firewalld.FlushAllOnReload|default('yes') }}
 # Defaults to "yes".
 RFC3964_IPv4={{ firewalld.RFC3964_IPv4|default('yes') }}
 {%- endif %}
+{%- if firewalld.get('AllowZoneDrifting', False) %}
+
+# AllowZoneDrifting
+# Older versions of firewalld had undocumented behavior known as "zone
+# drifting". This allowed packets to ingress multiple zones - this is a
+# violation of zone based firewalls. However, some users rely on this behavior
+# to have a "catch-all" zone, e.g. the default zone. You can enable this if you
+# desire such behavior. It's disabled by default for security reasons. Note: If
+# "yes" packets will only drift from source based zones to interface based
+# zones (including the default zone). Packets never drift from interface based
+# zones to other interfaces based zones (including the default zone). Valid
+# values; "yes", "no".
+# Defaults to "no".
+AllowZoneDrifting={{ firewalld.AllowZoneDrifting|default('no') }}
+{%- endif %}

--- a/pillar.example
+++ b/pillar.example
@@ -10,6 +10,7 @@ firewalld:
   FirewallBackend: 'nftables'
   FlushAllOnReload: 'yes'
   RFC3964_IPv4: 'yes'
+  AllowZoneDrifting: 'no'
 
   ipset:
     manage: true

--- a/test/integration/default/controls/yaml_dump_spec.rb
+++ b/test/integration/default/controls/yaml_dump_spec.rb
@@ -5,6 +5,7 @@ control 'firewalld `map.jinja` YAML dump' do
 
   yaml_dump = "---\n"
   yaml_dump += <<~YAML_DUMP.chomp
+    AllowZoneDrifting: 'no'
     AutomaticHelpers: system
     FirewallBackend: nftables
     FlushAllOnReload: 'yes'


### PR DESCRIPTION
<!--
Please fill in this PR template to make it easier to review and merge.

It has been designed so that a lot of it can be completed *after* submitting it,
e.g. filling in the checklists.

Notes:
1. Please keep the PR as small as is practicable; the larger a PR gets, the harder it becomes to review and the more time it requires to get it merged.
2. Similarly, please avoid PRs that cover more than one type; it should be a _bug fix_ *OR* a _new feature_ *OR* a _refactor_, etc.
3. Please direct questions to the [`#formulas` channel on Slack](https://saltstackcommunity.slack.com/messages/C7LG8SV54/), which is bridged to `#saltstack-formulas` on Freenode.
4. Feel free to suggest improvements to this template by reporting an issue or submitting a PR.  The source of this template is:
  - https://github.com/saltstack-formulas/.github/blob/master/.github/pull_request_template.md
-->

### PR progress checklist (to be filled in by reviewers)
<!-- Please leave this checklist for reviewers to tick as they work through the PR. -->

- [ ] Changes to documentation are appropriate (or tick if not required)
- [ ] Changes to tests are appropriate (or tick if not required)
- [ ] Reviews completed

---

### What type of PR is this?
<!-- Please tick each box that is relevant (after creating the PR). -->

#### Primary type
<!-- There really should be only *one* of these types ticked for each PR. -->

- [ ] `[build]`    Changes related to the build system
- [ ] `[chore]`    Changes to the build process or auxiliary tools and libraries such as documentation generation
- [ ] `[ci]`       Changes to the continuous integration configuration
- [x] `[feat]`     A new feature
- [ ] `[fix]`      A bug fix
- [ ] `[perf]`     A code change that improves performance
- [ ] `[refactor]` A code change that neither fixes a bug nor adds a feature
- [ ] `[revert]`   A change used to revert a previous commit
- [ ] `[style]`    Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc.)

#### Secondary type
<!-- Most PRs should include all of the following types as well. -->

- [ ] `[docs]`     Documentation changes
- [ ] `[test]`     Adding missing or correcting existing tests

### Does this PR introduce a `BREAKING CHANGE`?
<!-- If so, change the following to a `Yes` and explain what the breaking changes are. -->
<!-- If there are multiple breaking changes, list them all. -->

No.

### Related issues and/or pull requests
<!-- Please link any related issues/PRs here, especially any issues that are closed by this PR. -->

Close #44.

### Describe the changes you're proposing
<!-- A clear and concise description of what you have implemented. -->
<!-- Consider explaining each commit if they cover different aspects of the proposed changes. -->

See #44.

Configuration description taken from:

* https://firewalld.org/documentation/man-pages/firewalld.conf.html

### Pillar / config required to test the proposed changes
<!-- Provide links to the SLS files and/or relevant configs (be sure to remove sensitive info). -->



### Debug log showing how the proposed changes work
<!-- Include a debug log showing how these changes work, e.g. using `salt-minion -l debug`. -->
<!-- Alternatively, linking to Kitchen debug logs is useful, e.g. via. Travis CI. -->
<!-- Most useful is providing a passing InSpec test, which can be used to verify any proposed changes. -->



### Documentation checklist
<!-- Please tick each box that is relevant (after creating the PR). -->

- [ ] Updated the `README` (e.g. `Available states`).
- [x] Updated `pillar.example`.

### Testing checklist
<!-- Please tick each box that is relevant (after creating the PR). -->

- [x] Included in Kitchen (i.e. under `state_top`).
- [x] Covered by new/existing tests (e.g. InSpec, Serverspec, etc.).
- [x] Updated the relevant test pillar.

### Additional context
<!-- Add any other context about the proposed changes here. -->


