### PR TITLE
feat(zone.xml): Allow to rate limit 'accept' in rich rules

### DIFF
--- a/firewalld/files/zone.xml
+++ b/firewalld/files/zone.xml
@@ -60,7 +60,7 @@
     <audit>{%- if 'limit' in rule.audit %} <limit value="{{ rule.audit.limit }}"/>{%- endif %}</audit>
   {%- endif %}
   {%- if 'accept' in rule %}
-    <accept/>
+    <accept>{%- if rule.accept is mapping and 'limit' in rule.accept %} <limit value="{{ rule.accept.limit }}"/>{%- endif %}</accept>
   {%- endif %}
   {%- if 'reject' in rule %}
     <reject{%- if 'type' in rule.reject %} type="{{ rule.reject.type }}"{%- endif %} />

--- a/pillar.example
+++ b/pillar.example
@@ -126,6 +126,14 @@ firewalld:
             name: fail2ban-ssh
           reject:
             type: icmp-port-unreachable
+        - accept:
+            limit: "3/m"
+          log:
+            level: warning
+            limit: "3/m"
+            prefix: "http fw limit 3/m"
+          service: http
+
       ports:
         # {%- if grains['id'] == 'salt.example.com' %}
         - comment: salt-master

--- a/test/integration/default/controls/zones_spec.rb
+++ b/test/integration/default/controls/zones_spec.rb
@@ -31,7 +31,7 @@ control 'zones/public.xml configuration' do
           <source-port port="4444" protocol="tcp" />
           <rule family="ipv4">
             <source address="8.8.8.8/24" />
-            <accept/>
+            <accept></accept>
           </rule>
           <rule family="ipv4">
             <source ipset="fail2ban-ssh" />
@@ -59,12 +59,12 @@ control 'zones/rich_public.xml configuration' do
           <rule>
             <source ipset="fail2ban-ssh" />
             <service name="ssh" />
-            <accept/>
+            <accept></accept>
           </rule>
           <rule>
             <source ipset="other-ipset" />
             <service name="ssh" />
-            <accept/>
+            <accept></accept>
           </rule>
         </zone>
       ZONE_XML

--- a/test/integration/default/controls/zones_spec.rb
+++ b/test/integration/default/controls/zones_spec.rb
@@ -37,6 +37,13 @@ control 'zones/public.xml configuration' do
             <source ipset="fail2ban-ssh" />
             <reject type="icmp-port-unreachable" />
           </rule>
+          <rule>
+            <service name="http" />
+            <log prefix="http fw limit 3/m" level="warning">
+              <limit value="3/m"/>
+            </log>
+            <accept> <limit value="3/m"/></accept>
+          </rule>
         </zone>
       ZONE_XML
     end

--- a/test/integration/default/files/_mapdata/amazonlinux-2.yaml
+++ b/test/integration/default/files/_mapdata/amazonlinux-2.yaml
@@ -134,6 +134,13 @@ values:
           name: fail2ban-ssh
         reject:
           type: icmp-port-unreachable
+      - accept:
+          limit: "3/m"
+        log:
+          level: warning
+          limit: "3/m"
+          prefix: "http fw limit 3/m"
+        service: http
       services:
       - http
       - https

--- a/test/integration/default/files/_mapdata/arch-base-latest.yaml
+++ b/test/integration/default/files/_mapdata/arch-base-latest.yaml
@@ -134,6 +134,13 @@ values:
           name: fail2ban-ssh
         reject:
           type: icmp-port-unreachable
+      - accept:
+          limit: "3/m"
+        log:
+          level: warning
+          limit: "3/m"
+          prefix: "http fw limit 3/m"
+        service: http
       services:
       - http
       - https

--- a/test/integration/default/files/_mapdata/centos-7.yaml
+++ b/test/integration/default/files/_mapdata/centos-7.yaml
@@ -134,6 +134,13 @@ values:
           name: fail2ban-ssh
         reject:
           type: icmp-port-unreachable
+      - accept:
+          limit: "3/m"
+        log:
+          level: warning
+          limit: "3/m"
+          prefix: "http fw limit 3/m"
+        service: http
       services:
       - http
       - https

--- a/test/integration/default/files/_mapdata/centos-8.yaml
+++ b/test/integration/default/files/_mapdata/centos-8.yaml
@@ -134,6 +134,13 @@ values:
           name: fail2ban-ssh
         reject:
           type: icmp-port-unreachable
+      - accept:
+          limit: "3/m"
+        log:
+          level: warning
+          limit: "3/m"
+          prefix: "http fw limit 3/m"
+        service: http
       services:
       - http
       - https

--- a/test/integration/default/files/_mapdata/debian-10.yaml
+++ b/test/integration/default/files/_mapdata/debian-10.yaml
@@ -134,6 +134,13 @@ values:
           name: fail2ban-ssh
         reject:
           type: icmp-port-unreachable
+      - accept:
+          limit: "3/m"
+        log:
+          level: warning
+          limit: "3/m"
+          prefix: "http fw limit 3/m"
+        service: http
       services:
       - http
       - https

--- a/test/integration/default/files/_mapdata/debian-9.yaml
+++ b/test/integration/default/files/_mapdata/debian-9.yaml
@@ -134,6 +134,13 @@ values:
           name: fail2ban-ssh
         reject:
           type: icmp-port-unreachable
+      - accept:
+          limit: "3/m"
+        log:
+          level: warning
+          limit: "3/m"
+          prefix: "http fw limit 3/m"
+        service: http
       services:
       - http
       - https

--- a/test/integration/default/files/_mapdata/fedora-31.yaml
+++ b/test/integration/default/files/_mapdata/fedora-31.yaml
@@ -134,6 +134,13 @@ values:
           name: fail2ban-ssh
         reject:
           type: icmp-port-unreachable
+      - accept:
+          limit: "3/m"
+        log:
+          level: warning
+          limit: "3/m"
+          prefix: "http fw limit 3/m"
+        service: http
       services:
       - http
       - https

--- a/test/integration/default/files/_mapdata/fedora-32.yaml
+++ b/test/integration/default/files/_mapdata/fedora-32.yaml
@@ -134,6 +134,13 @@ values:
           name: fail2ban-ssh
         reject:
           type: icmp-port-unreachable
+      - accept:
+          limit: "3/m"
+        log:
+          level: warning
+          limit: "3/m"
+          prefix: "http fw limit 3/m"
+        service: http
       services:
       - http
       - https

--- a/test/integration/default/files/_mapdata/opensuse-15.yaml
+++ b/test/integration/default/files/_mapdata/opensuse-15.yaml
@@ -134,6 +134,13 @@ values:
           name: fail2ban-ssh
         reject:
           type: icmp-port-unreachable
+      - accept:
+          limit: "3/m"
+        log:
+          level: warning
+          limit: "3/m"
+          prefix: "http fw limit 3/m"
+        service: http
       services:
       - http
       - https

--- a/test/integration/default/files/_mapdata/ubuntu-16.yaml
+++ b/test/integration/default/files/_mapdata/ubuntu-16.yaml
@@ -134,6 +134,13 @@ values:
           name: fail2ban-ssh
         reject:
           type: icmp-port-unreachable
+      - accept:
+          limit: "3/m"
+        log:
+          level: warning
+          limit: "3/m"
+          prefix: "http fw limit 3/m"
+        service: http
       services:
       - http
       - https

--- a/test/integration/default/files/_mapdata/ubuntu-18.yaml
+++ b/test/integration/default/files/_mapdata/ubuntu-18.yaml
@@ -134,6 +134,13 @@ values:
           name: fail2ban-ssh
         reject:
           type: icmp-port-unreachable
+      - accept:
+          limit: "3/m"
+        log:
+          level: warning
+          limit: "3/m"
+          prefix: "http fw limit 3/m"
+        service: http
       services:
       - http
       - https

--- a/test/integration/default/files/_mapdata/ubuntu-20.yaml
+++ b/test/integration/default/files/_mapdata/ubuntu-20.yaml
@@ -134,6 +134,13 @@ values:
           name: fail2ban-ssh
         reject:
           type: icmp-port-unreachable
+      - accept:
+          limit: "3/m"
+        log:
+          level: warning
+          limit: "3/m"
+          prefix: "http fw limit 3/m"
+        service: http
       services:
       - http
       - https


### PR DESCRIPTION
The current rich_rule macro is supporting to set if the connection
should be accepted or rejected or dropped but doesn't support setting
rate limiting in the 'accept' case. Add code for that.

Signed-off-by: Arnaud Patard <apatard@hupstream.com>